### PR TITLE
Add link to PGP public key & SHA256 guide

### DIFF
--- a/coldcard/upgrade.md
+++ b/coldcard/upgrade.md
@@ -44,6 +44,8 @@ Please look for signing key: `[4589779ADFC14F3327534EA8A3A31BAD5A2A5B10](https:/
 Don't forget to run SHA256 over the DFU files themselves, because that compares
 your actual file contents to what we signed.
 
+    sha256sum 2019-12-19T1623-v3.0.6-coldcard.dfu
+
 Github.com is also protecting us because it verifies on all commits
 against the developer's public keys, and keeps a history of changes.
 

--- a/coldcard/upgrade.md
+++ b/coldcard/upgrade.md
@@ -39,7 +39,7 @@ and GPG. The commands are:
     curl https://pgp.key-server.io/download/0xA3A31BAD5A2A5B10 | gpg --import
     gpg --verify signatures.txt
 
-Please look for signing key: `4589779ADFC14F3327534EA8A3A31BAD5A2A5B10`
+Please look for signing key: `[4589779ADFC14F3327534EA8A3A31BAD5A2A5B10](https://pgp.key-server.io/pks/lookup?op=get&search=0xA3A31BAD5A2A5B10)`
 
 Don't forget to run SHA256 over the DFU files themselves, because that compares
 your actual file contents to what we signed.


### PR DESCRIPTION
This adds the link to the key server public key. Though you might want to link to another source, like keybase, or even better add the public key to your github repo...

It also adds a SHA256 guide.